### PR TITLE
Add encode option. #1

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "chokidar": "^2.0.3",
     "commander": "^2.15.1",
     "discord.js": "^11.3.2",
+    "iconv-lite": "^0.4.23",
     "modern-rcon": "^1.0.3"
   }
 }

--- a/src/Tail.js
+++ b/src/Tail.js
@@ -3,11 +3,13 @@ import { createReadStream, statSync } from 'fs'
 import { createInterface } from 'readline'
 import { dirname } from 'path'
 import { watch } from 'chokidar'
+import { decodeStream } from 'iconv-lite'
 
 export default class Tail extends EventEmitter {
-  constructor (filename) {
+  constructor (filename, encode) {
     super()
     this.filename = filename
+    this.encode = encode || 'utf-8'
     this.watcher = null
     this.position = 0
     this.watch()
@@ -63,8 +65,7 @@ export default class Tail extends EventEmitter {
       input: createReadStream(this.filename, {
         start: this.position,
         end: stats.size - 1,
-        encoding: 'utf-8',
-      })
+      }).pipe(decodeStream(this.encode))
     }).on('line', line => {
       this.emit('line', line)
     })

--- a/src/config.js
+++ b/src/config.js
@@ -10,7 +10,8 @@ const configDefault = {
   minecraftRconPort: 25575,
   minecraftRconPassword: '',
   discordBotToken: '',
-  discordChannel: ''
+  discordChannel: '',
+  encode: 'utf-8',
 }
 
 program
@@ -25,6 +26,7 @@ program
   .option('--minecraft-rcon-password <password>', 'set the Minecraft Server rcon password (It is recommended to specify them collectively in the configuration file)')
   .option('--discord-bot-token <token>', 'set Discord bot token (It is recommended to specify them collectively in the configuration file)')
   .option('--discord-channel <id>', 'set Discord channel ID for for the discord bot (It is recommended to specify them collectively in the configuration file)')
+  .option('--encode <charset>', 'set characterset of log file (default: utf-8)')
   .parse(process.argv)
 
 let cache = null
@@ -44,5 +46,6 @@ export default async () => {
     minecraftRconPassword: program.minecraftRconPassword || config.minecraftRconPassword || configDefault.minecraftRconPassword,
     discordBotToken: program.discordBotToken || config.discordBotToken || configDefault.discordBotToken,
     discordChannel: program.discordChannel || config.discordChannel || configDefault.discordChannel,
+    encode: program.encode || config.encode || configDefault.encode,
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,7 @@ import { loadPlugins } from './Plugin'
     minecraftRconPassword,
     discordBotToken,
     discordChannel,
+    encode,
   } = await config()
 
   process.stdout.write('Starting Minecord ... ')
@@ -25,7 +26,7 @@ import { loadPlugins } from './Plugin'
 
   const client = new Client()
   const rcon = new Rcon(minecraftRconHost, minecraftRconPort, minecraftRconPassword)
-  const tail = new Tail(minecraftLog)
+  const tail = new Tail(minecraftLog, encode)
 
   let channel
 


### PR DESCRIPTION
* Add `encode` option to config file and command line argument.
* (If there is no `encode` setting, use `utf-8` as default.)
* Read `latest.log` with [iconv-lite](https://www.npmjs.com/package/iconv-lite) module.
* Related issue: #1 

Sorry, I tested it only on Windows, because I do not have other environment. :cry: